### PR TITLE
Add content to homepage

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -1,0 +1,27 @@
+/* override the default image top css */
+.sd-card-img-top {
+    width: 15% !important;
+    position: absolute !important;
+    padding-left: 10px;
+    min-width: 50px;
+    top: 50%;
+    transform: translateY(-50%);
+
+}
+
+/* override the default background image behavior */
+.sd-card-img {
+    height: auto;
+}
+
+/* override toc css */
+/* controls dropdown icon color */
+.bd-toc-item.active {
+    margin-bottom: 1rem;
+    color: #012169;
+}
+
+/* controls sidebar header color */
+.caption-text {
+    color: #012169;
+}

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,0 +1,15 @@
+/* delete margin from side of content */
+.wy-nav-content {
+    max-width: none !important;
+}
+
+.custom-title {
+    font-weight: bold;
+    color: #012169;
+    text-align: left;
+}
+
+.custom-body {
+    text-align: left;
+    margin-left: max(45px, 15%);
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,8 +68,18 @@ html_static_path = ['_static']
 # set to "auto" for default behavior
 nb_execution_mode = "auto"
 
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+html_css_files = ["style.css"]
+
 # pull in the notebooks and images from the source directory
 if os.path.exists("./notebooks/"):
     os.system("rm -rf ./notebooks/")
 os.system("mkdir ./notebooks/")
 os.system("cp -r ../notebooks/* ./notebooks/")
+
+# Allow for changes to be made to the css in the theme_overrides file
+def setup(app):
+    app.add_css_file('theme_overrides.css')

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,8 @@
 
 GeoCAT-tutorials
 =================
-Welcome to GeoCAT-tutorials!
+Welcome to GeoCAT-tutorials! This version of this content was made for 
+presentation at the Fall 2022 ESDS event.
 
 .. toctree::
    :maxdepth: 1
@@ -33,3 +34,25 @@ Welcome to GeoCAT-tutorials!
    :maxdepth: 1
    :hidden:
    :caption: UXarray
+
+
+.. grid:: 1 1 2 2
+    :gutter: 2
+
+    .. grid-item-card:: GeoCAT Overview
+         :link: ./notebooks/geocat/00-Overview.ipynb
+
+         GeoCAT team and projects
+
+    .. grid-item-card:: GeoCAT-viz
+   
+         GeoCAT's visualization library
+
+    .. grid-item-card:: GeoCAT-comp
+         :link: ./notebooks/geocat-comp/00-Introduction.ipynb
+
+         GeoCAT's computational library
+
+    .. grid-item-card:: UXarray
+        
+         Tools for unstructured grids


### PR DESCRIPTION
Addresses #7 

Summary of changes:
- adds cards with links to tutorial sections (if they were on main)
- Adds custom css that can be used later to match the formatting on other geocat repos

<img width="860" alt="image" src="https://user-images.githubusercontent.com/38434768/199317873-796d9e78-335d-48bf-8ab4-cc7bd147f404.png">

Feel free to suggest alternate wording for the cards 
